### PR TITLE
Add property lineNumber for XML documents

### DIFF
--- a/src/main/asciidoc/1.5.adoc
+++ b/src/main/asciidoc/1.5.adoc
@@ -1,4 +1,4 @@
 ifndef::jqa-in-manual[== Version 1.5]
 ifdef::jqa-in-manual[== XML Plugin 1.5]
 
-To be written.
+- Add property lineNumber to :Xml:Document, :Xml:Element, :Xml:CData and :Xml:Text

--- a/src/main/asciidoc/scanner.adoc
+++ b/src/main/asciidoc/scanner.adoc
@@ -42,6 +42,7 @@ Represents an XML document.
 | standalone              | The "standalone" attribute of the XML declaration.
 | characterEncodingScheme | The encoding of the XML file.
 | xmlWellFormed           | Indicates if the document is well-formed, i.e. could be parsed.
+| lineNumber              | Last line number
 |====
 
 .Relations of :Xml:Document
@@ -55,6 +56,14 @@ Represents an XML document.
 === :Xml:Element
 An XML element.
 
+.Properties of :Xml:Element
+[options="header"]
+|====
+| Name       | Description
+| value      | The text value.
+| lineNumber | Last line number of the start tag of the element.
+|====
+
 .Relations of :Xml:Element
 [options="header"]
 |====
@@ -65,6 +74,7 @@ An XML element.
 | HAS_ATTRIBUTE      | <<:Xml:Attribute>> | 0..n         | References attributes of the element.
 | HAS_TEXT           | <<:Xml:Text>>      | 0..n         | References the text values of the element.
 |====
+
 
 [[:Xml:Namespace]]
 === :Xml:Namespace
@@ -103,11 +113,12 @@ An XML attribute.
 === :Xml:Text
 A text value of an XML element.
 
-.Properties of :Xml:Element
+.Properties of :Xml:Text
 [options="header"]
 |====
-| Name   | Description
-| value  | The text value.
+| Name       | Description
+| value      | The text value.
+| lineNumber | Last line number
 |====
 
 [[XsdFileScanner]]

--- a/src/main/java/com/buschmais/jqassistant/plugin/xml/api/model/LineNumberDescriptor.java
+++ b/src/main/java/com/buschmais/jqassistant/plugin/xml/api/model/LineNumberDescriptor.java
@@ -1,0 +1,16 @@
+
+package com.buschmais.jqassistant.plugin.xml.api.model;
+
+import com.buschmais.xo.neo4j.api.annotation.Property;
+
+/**
+ * Defines a descriptor containing line number information.
+ */
+public interface LineNumberDescriptor {
+
+    @Property("lineNumber")
+    Integer getLineNumber();
+
+    void setLineNumber(Integer lineNumber);
+
+}

--- a/src/main/java/com/buschmais/jqassistant/plugin/xml/api/model/XmlDocumentDescriptor.java
+++ b/src/main/java/com/buschmais/jqassistant/plugin/xml/api/model/XmlDocumentDescriptor.java
@@ -5,7 +5,7 @@ import com.buschmais.xo.neo4j.api.annotation.Relation;
 import com.buschmais.xo.neo4j.api.annotation.Relation.Outgoing;
 
 @Label("Document")
-public interface XmlDocumentDescriptor extends XmlDescriptor {
+public interface XmlDocumentDescriptor extends XmlDescriptor, LineNumberDescriptor {
 
     @Relation("HAS_ROOT_ELEMENT")
     @Outgoing

--- a/src/main/java/com/buschmais/jqassistant/plugin/xml/api/model/XmlElementDescriptor.java
+++ b/src/main/java/com/buschmais/jqassistant/plugin/xml/api/model/XmlElementDescriptor.java
@@ -13,7 +13,7 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @Label("Element")
-public interface XmlElementDescriptor extends XmlDescriptor, OfNamespaceDescriptor, SiblingDescriptor {
+public interface XmlElementDescriptor extends XmlDescriptor, OfNamespaceDescriptor, SiblingDescriptor, LineNumberDescriptor {
 
     @Outgoing
     @HasElement

--- a/src/main/java/com/buschmais/jqassistant/plugin/xml/api/model/XmlTextDescriptor.java
+++ b/src/main/java/com/buschmais/jqassistant/plugin/xml/api/model/XmlTextDescriptor.java
@@ -3,7 +3,7 @@ package com.buschmais.jqassistant.plugin.xml.api.model;
 import com.buschmais.xo.neo4j.api.annotation.Label;
 
 @Label("Text")
-public interface XmlTextDescriptor extends XmlDescriptor, SiblingDescriptor{
+public interface XmlTextDescriptor extends XmlDescriptor, SiblingDescriptor, LineNumberDescriptor {
 
     String getValue();
 

--- a/src/main/java/com/buschmais/jqassistant/plugin/xml/impl/scanner/XmlSourceScannerPlugin.java
+++ b/src/main/java/com/buschmais/jqassistant/plugin/xml/impl/scanner/XmlSourceScannerPlugin.java
@@ -48,6 +48,7 @@ public class XmlSourceScannerPlugin extends AbstractScannerPlugin<Source, XmlDoc
         Map<XmlElementDescriptor, SiblingDescriptor> siblings = new HashMap<>();
         try {
             XMLStreamReader streamReader = inputFactory.createXMLStreamReader(item);
+
             while (streamReader.hasNext()) {
                 int eventType = streamReader.getEventType();
                 switch (eventType) {
@@ -104,6 +105,7 @@ public class XmlSourceScannerPlugin extends AbstractScannerPlugin<Source, XmlDoc
         documentDescriptor.setXmlVersion(streamReader.getVersion());
         documentDescriptor.setCharacterEncodingScheme(streamReader.getCharacterEncodingScheme());
         documentDescriptor.setStandalone(streamReader.isStandalone());
+        documentDescriptor.setLineNumber(streamReader.getLocation().getLineNumber());
         return documentDescriptor;
     }
 
@@ -135,6 +137,9 @@ public class XmlSourceScannerPlugin extends AbstractScannerPlugin<Source, XmlDoc
             attributeDescriptor.setValue(streamReader.getAttributeValue(i));
             elementDescriptor.getAttributes().add(attributeDescriptor);
         }
+
+        elementDescriptor.setLineNumber(streamReader.getLocation().getLineNumber());
+
         return elementDescriptor;
     }
 
@@ -157,6 +162,7 @@ public class XmlSourceScannerPlugin extends AbstractScannerPlugin<Source, XmlDoc
             if (!Strings.isNullOrEmpty(text)) {
                 T textDescriptor = store.create(type);
                 textDescriptor.setValue(text);
+                textDescriptor.setLineNumber(streamReader.getLocation().getLineNumber());
                 parentElement.getCharacters().add(textDescriptor);
                 return textDescriptor;
             }

--- a/src/test/java/com/buschmais/jqassistant/plugin/xml/test/XmlFileScannerIT.java
+++ b/src/test/java/com/buschmais/jqassistant/plugin/xml/test/XmlFileScannerIT.java
@@ -72,9 +72,11 @@ public class XmlFileScannerIT extends AbstractPluginIT {
         assertThat(xmlDocumentDescriptor.getXmlVersion(), equalTo("1.0"));
         assertThat(xmlDocumentDescriptor.getCharacterEncodingScheme(), equalTo("UTF-8"));
         assertThat(xmlDocumentDescriptor.isStandalone(), equalTo(false));
+        assertThat(xmlDocumentDescriptor.getLineNumber(), equalTo(1));
         XmlElementDescriptor rootElement = xmlDocumentDescriptor.getRootElement();
         assertThat(rootElement, notNullValue());
         assertThat(rootElement.getName(), equalTo("RootElement"));
+        assertThat(rootElement.getLineNumber(), equalTo(2));
         List<XmlNamespaceDescriptor> rootNamespaces = rootElement.getDeclaredNamespaces();
         assertThat(rootNamespaces.size(), equalTo(1));
         XmlNamespaceDescriptor rootNS = rootNamespaces.get(0);
@@ -97,6 +99,7 @@ public class XmlFileScannerIT extends AbstractPluginIT {
 
     private void verifyChildElement(XmlElementDescriptor childElement) {
         assertThat(childElement.getDeclaredNamespaces().size(), equalTo(0));
+        assertThat(childElement.getLineNumber(), equalTo(3));
         List<XmlAttributeDescriptor> childElementAttributes = childElement.getAttributes();
         assertThat(childElementAttributes.size(), equalTo(1));
         XmlAttributeDescriptor childElementAttribute = childElementAttributes.get(0);
@@ -105,10 +108,12 @@ public class XmlFileScannerIT extends AbstractPluginIT {
         assertThat(childElementTexts.size(), equalTo(1));
         XmlTextDescriptor childElementText = childElementTexts.get(0);
         assertThat(childElementText.getValue(), equalTo("Child Text"));
+        assertThat(childElementText.getLineNumber(), equalTo(5));
     }
 
     private void verifyExtraElement(XmlElementDescriptor childElement) {
         assertThat(childElement.getDeclaredNamespaces().size(), equalTo(1));
+        assertThat(childElement.getLineNumber(), equalTo(6));
         XmlNamespaceDescriptor extraNamespace = childElement.getDeclaredNamespaces().get(0);
         assertThat(extraNamespace.getUri(), equalTo("http://jqassistant.org/plugin/xml/test/extra"));
         assertThat(extraNamespace.getPrefix(), equalTo("extra"));
@@ -118,11 +123,13 @@ public class XmlFileScannerIT extends AbstractPluginIT {
         assertThat(extraChildElements.size(), equalTo(1));
         XmlElementDescriptor extraChildElement = extraChildElements.get(0);
         assertThat(extraChildElement.getName(), equalTo("ExtraChildElement"));
+        assertThat(extraChildElement.getLineNumber(), equalTo(7));
         assertThat(extraChildElement.getNamespaceDeclaration(), equalTo(extraNamespace));
         List<XmlTextDescriptor> extraChildElementTexts = extraChildElement.getCharacters();
         assertThat(extraChildElementTexts.size(), equalTo(1));
         XmlTextDescriptor extraChildElementText = extraChildElementTexts.get(0);
         assertThat(extraChildElementText.getValue(), equalTo("Extra Child Text"));
+        assertThat(extraChildElementText.getLineNumber(), equalTo(7));
         List<XmlAttributeDescriptor> extraChildElementAttributes = extraChildElement.getAttributes();
         assertThat(extraChildElementAttributes.size(), equalTo(1));
         XmlAttributeDescriptor extraChildElementAttribute = extraChildElementAttributes.get(0);
@@ -131,18 +138,22 @@ public class XmlFileScannerIT extends AbstractPluginIT {
     }
 
     private void verifyMixedParentElement(XmlElementDescriptor childElement) {
+        assertThat(childElement.getLineNumber(), equalTo(9));
         XmlDescriptor mixedChildElement1 = childElement.getFirstChild();
         assertThat(mixedChildElement1, notNullValue());
         assertThat(mixedChildElement1, instanceOf(XmlElementDescriptor.class));
         assertThat(((XmlElementDescriptor) mixedChildElement1).getName(), equalTo("MixedChildElement1"));
+        assertThat(((XmlElementDescriptor) mixedChildElement1).getLineNumber(), equalTo(10));
         XmlDescriptor mixedChildText = ((XmlElementDescriptor) mixedChildElement1).getNextSibling();
         assertThat(mixedChildText, notNullValue());
         assertThat(mixedChildText, instanceOf(XmlTextDescriptor.class));
         assertThat(((XmlTextDescriptor) mixedChildText).getValue(), equalTo("Mixed Parent Text"));
+        assertThat(((XmlTextDescriptor) mixedChildText).getLineNumber(), equalTo(12));
         XmlDescriptor mixedChildElement2 = ((XmlTextDescriptor) mixedChildText).getNextSibling();
         assertThat(mixedChildElement2, notNullValue());
         assertThat(mixedChildElement2, instanceOf(XmlElementDescriptor.class));
         assertThat(((XmlElementDescriptor) mixedChildElement2).getName(), equalTo("MixedChildElement2"));
+        assertThat(((XmlElementDescriptor) mixedChildElement2).getLineNumber(), equalTo(12));
         assertThat(childElement.getLastChild(), equalTo(mixedChildElement2));
     }
 


### PR DESCRIPTION
This pull requests adds the property to nodes labeled with to :Xml:Document, :Xml:Text and :Xml:Element.

The line number is always the line the element ends on. This is because I could not find an easy way how to get the first line of the element out of `streamReader`.

I think this pull request is useful anyways. I analyze some huge XML files with `jQAssistant`. It would be very helpful to know the line number when searching for reported constraint violations.